### PR TITLE
upgrade eslint and use the higher level CLIEngine interface

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,106 +1,28 @@
-var path = require( 'path' );
-var chalk = require( 'chalk' );
-var linter = require( 'eslint' ).linter;
-var sander = require( 'sander' );
-var promiseMapSeries = require( 'promise-map-series' );
-var findup = require( 'findup-sync' );
-var sorcery = require( 'sorcery' );
-var logSyntaxError = require( 'log-syntax-error' );
-
-var eslintrc = findup( '.eslintrc' );
-var defaultOptions;
-
-if ( eslintrc ) {
-	try {
-		defaultOptions = JSON.parse( require( 'fs' ).readFileSync( eslintrc ) );
-	} catch ( err ) {
-		throw new Error( 'Could not parse .eslintrc file. It must be valid JSON' );
-	}
-}
+var Linter = require( 'eslint' ).CLIEngine;
 
 module.exports = function eslint ( inputdir, options ) {
 	var log = this.log;
 
 	var reportOnly = options.reportOnly;
-	var reporter = options.reporter || defaultReporter;
+	var reporter = options.reporter;
 
 	delete options.reporter;
 	delete options.reportOnly;
 
-	if ( !Object.keys( options ).length ) {
-		options = defaultOptions;
-	}
+  // This is necessary for eslint to lint files in .gobble directories
+  options.dotfiles = true;
 
-	var reports = [];
+  var linter = new Linter(options);
+  var reports = linter.executeOnFiles([ inputdir ]);
 
-	return sander.lsr( inputdir ).then( function ( files ) {
-		return promiseMapSeries( files.filter( isJs ), function ( file ) {
-			var filename = path.join( inputdir, file );
+  if ( reports.errorCount || reports.warningCount ) {
+    var formatter = Linter.getFormatter(reporter);
+    console.log(formatter( reports.results ));
 
-			return sander.readFile( filename )
-				.then( String )
-				.then( function ( code ) {
-					log( 'linting ' + file );
-					var messages = linter.verify( code, options, filename );
+    if ( !reportOnly && reports.errorCount ) {
+      throw new Error( 'Linting failed' );
+    }
+  }
 
-					if ( messages.length ) {
-						reports.push({
-							filename: filename,
-							messages: messages.sort( bySeverity )
-						});
-					}
-				});
-		});
-	}).then( function () {
-		if ( reports.length ) {
-			reporter( reports );
-
-			if ( !reportOnly ) {
-				throw new Error( 'Linting failed' );
-			}
-		}
-	});
+  return Promise.resolve();
 };
-
-function isJs ( file ) {
-	return /\.js$/.test( file );
-}
-
-function bySeverity ( a, b ) {
-	return b.severity - a.severity;
-}
-
-function defaultReporter ( reports ) {
-	reports.forEach( function ( report ) {
-		var numErrors = report.messages.length;
-		var chain = sorcery.loadSync( report.filename );
-
-		var source = sander.readFileSync( report.filename ).toString();
-
-		console.log( '===\n\n%s %s in %s', numErrors, numErrors === 1 ? 'error' : 'errors', report.filename );
-
-		report.messages.forEach( function ( message ) {
-			var block, originalLocation, originalSource;
-
-			console.log( '\n---\n' );
-
-			console.log( message.message );
-			block = logSyntaxError( source, message.line, message.column );
-			console.log( block );
-
-			if ( chain ) {
-				originalLocation = chain.trace( message.line, message.column );
-
-				if ( originalLocation ) {
-					originalSource = sander.readFileSync( originalLocation.source ).toString();
-
-					console.log( '\noriginal source: ' + originalLocation.source );
-					block = logSyntaxError( originalSource, originalLocation.line, originalLocation.column );
-					console.log( block );
-				}
-			}
-		});
-	});
-
-	console.log( '\n\n' );
-}

--- a/package.json
+++ b/package.json
@@ -6,13 +6,7 @@
   "license": "MIT",
   "repository": "https://github.com/gobblejs/gobble-eslint",
   "dependencies": {
-    "chalk": "^1.0.0",
-    "eslint": "^0.18.0",
-    "findup-sync": "^0.2.1",
-    "log-syntax-error": "^0.1.0",
-    "promise-map-series": "^0.2.1",
-    "sander": "^0.2.2",
-    "sorcery": "^0.3.4"
+    "eslint": "^2.0"
   },
   "keywords": [
     "gobble",


### PR DESCRIPTION
The current gobble-eslint does not work for me:
- it tries to find .eslintrc but I use .eslintrc.json (which is recommended nowadays)
- it does not use eslint 2
- the output does not use the nice current formatter

So I redid it, using the higher level CLIEngine API that is likely more future proof as well.
But I removed the functionality about the sourcemap because I don't use it (I prefer to lint my source files than a transpiled file). So tell me what you think.
Do you think I should create a gobble-eslint-ng instead ?
